### PR TITLE
Whitespaced string support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rustyline = "6.1.2"
+rustyline = "8.2.0"
 yansi = "0.5.0"
-nix = "0.17.0"
+nix = "0.21.0"
 clap = "2.33.1"
+regex = "1.5.4"

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -181,7 +181,7 @@ impl<Context, E: Display> Repl<Context, E> {
     fn process_line(&mut self, line: String) -> Result<()> {
         let trimmed = line.trim();
         if !trimmed.is_empty() {
-            let r = regex::Regex::new(r#"("[^"]+|[\S]+)"#).unwrap();
+            let r = regex::Regex::new(r#"("[^"\n]+"|[\S]+)"#).unwrap();
             let args = r
                 .captures_iter(trimmed)
                 .map(|a| a[0].to_string())
@@ -427,6 +427,24 @@ mod tests {
                     .with_help("Do foo when you can"),
             );
         run_repl(repl, "foo \"baz test 123\" foo\n", Ok(()));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_string_with_spaces_for_argument_last() -> Result<()> {
+        let repl = Repl::new(())
+            .with_name("test")
+            .with_version("v0.1.0")
+            .with_description("Testing 1, 2, 3...")
+            .with_error_handler(test_error_handler)
+            .add_command(
+                Command::new("foo", foo)
+                    .with_parameter(Parameter::new("bar").set_required(true)?)?
+                    .with_parameter(Parameter::new("baz").set_required(true)?)?
+                    .with_help("Do foo when you can"),
+            );
+        run_repl(repl, "foo foo \"baz test 123\"\n", Ok(()));
 
         Ok(())
     }

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -109,7 +109,7 @@ impl<Context, E: Display> Repl<Context, E> {
         &self,
         command: &str,
         parameters: &[Parameter],
-        args: &[&str],
+        args: &[String],
     ) -> Result<HashMap<String, Value>> {
         if args.len() > parameters.len() {
             return Err(Error::TooManyArguments(command.into(), parameters.len()));
@@ -156,7 +156,7 @@ impl<Context, E: Display> Repl<Context, E> {
         Ok(())
     }
 
-    fn show_help(&self, args: &[&str]) -> Result<()> {
+    fn show_help(&self, args: &[String]) -> Result<()> {
         if args.is_empty() {
             self.help_viewer
                 .help_general(&self.help_context.as_ref().unwrap())?;
@@ -181,7 +181,8 @@ impl<Context, E: Display> Repl<Context, E> {
     fn process_line(&mut self, line: String) -> Result<()> {
         let trimmed = line.trim();
         if trimmed.len() > 0 {
-            let mut args = trimmed.split_whitespace().collect::<Vec<&str>>();
+            let r = regex::Regex::new(r#"("[^"]+|[\S]+)"#).unwrap();
+            let mut args = r.captures_iter(trimmed).map(|a|a[0].to_string()).map(|a|a.as_str()).collect::<Vec<&str>>();
             let command: String = args.drain(..1).collect();
             self.handle_command(&command, &args)?;
         }

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -184,7 +184,7 @@ impl<Context, E: Display> Repl<Context, E> {
             let r = regex::Regex::new(r#"("[^"\n]+"|[\S]+)"#).unwrap();
             let args = r
                 .captures_iter(trimmed)
-                .map(|a| a[0].to_string())
+                .map(|a| a[0].to_string().replace("\"", ""))
                 .collect::<Vec<String>>();
             let mut args = args.iter().fold(vec![], |mut state, a| {
                 state.push(a.as_str());

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -109,7 +109,7 @@ impl<Context, E: Display> Repl<Context, E> {
         &self,
         command: &str,
         parameters: &[Parameter],
-        args: &[String],
+        args: &[&str],
     ) -> Result<HashMap<String, Value>> {
         if args.len() > parameters.len() {
             return Err(Error::TooManyArguments(command.into(), parameters.len()));
@@ -156,7 +156,7 @@ impl<Context, E: Display> Repl<Context, E> {
         Ok(())
     }
 
-    fn show_help(&self, args: &[String]) -> Result<()> {
+    fn show_help(&self, args: &[&str]) -> Result<()> {
         if args.is_empty() {
             self.help_viewer
                 .help_general(&self.help_context.as_ref().unwrap())?;
@@ -180,9 +180,16 @@ impl<Context, E: Display> Repl<Context, E> {
 
     fn process_line(&mut self, line: String) -> Result<()> {
         let trimmed = line.trim();
-        if trimmed.len() > 0 {
+        if !trimmed.is_empty() {
             let r = regex::Regex::new(r#"("[^"]+|[\S]+)"#).unwrap();
-            let mut args = r.captures_iter(trimmed).map(|a|a[0].to_string()).map(|a|a.as_str()).collect::<Vec<&str>>();
+            let args = r
+                .captures_iter(trimmed)
+                .map(|a| a[0].to_string())
+                .collect::<Vec<String>>();
+            let mut args = args.iter().fold(vec![], |mut state, a| {
+                state.push(a.as_str());
+                state
+            });
             let command: String = args.drain(..1).collect();
             self.handle_command(&command, &args)?;
         }
@@ -269,43 +276,45 @@ mod tests {
 
     fn run_repl<Context>(mut repl: Repl<Context, Error>, input: &str, expected: Result<()>) {
         let (rdr, wrtr) = pipe().unwrap();
-        match fork() {
-            Ok(ForkResult::Parent { child, .. }) => {
-                // Parent
-                let mut f = unsafe { File::from_raw_fd(wrtr) };
-                write!(f, "{}", input).unwrap();
-                if let WaitStatus::Exited(_, exit_code) = waitpid(child, None).unwrap() {
-                    assert!(exit_code == 0);
-                };
-            }
-            Ok(ForkResult::Child) => {
-                std::panic::set_hook(Box::new(|panic_info| {
-                    println!("Caught panic: {:?}", panic_info);
-                    if let Some(location) = panic_info.location() {
-                        println!(
-                            "panic occurred in file '{}' at line {}",
-                            location.file(),
-                            location.line(),
-                        );
-                    } else {
-                        println!("panic occurred but can't get location information...");
-                    }
-                }));
-
-                dup2(rdr, 0).unwrap();
-                close(rdr).unwrap();
-                let mut editor: rustyline::Editor<()> = rustyline::Editor::new();
-                let mut eof = false;
-                let result = repl.handle_line(&mut editor, &mut eof);
-                let _ = std::panic::take_hook();
-                if expected == result {
-                    std::process::exit(0);
-                } else {
-                    eprintln!("Expected {:?}, got {:?}", expected, result);
-                    std::process::exit(1);
+        unsafe {
+            match fork() {
+                Ok(ForkResult::Parent { child, .. }) => {
+                    // Parent
+                    let mut f = File::from_raw_fd(wrtr);
+                    write!(f, "{}", input).unwrap();
+                    if let WaitStatus::Exited(_, exit_code) = waitpid(child, None).unwrap() {
+                        assert!(exit_code == 0);
+                    };
                 }
+                Ok(ForkResult::Child) => {
+                    std::panic::set_hook(Box::new(|panic_info| {
+                        println!("Caught panic: {:?}", panic_info);
+                        if let Some(location) = panic_info.location() {
+                            println!(
+                                "panic occurred in file '{}' at line {}",
+                                location.file(),
+                                location.line(),
+                            );
+                        } else {
+                            println!("panic occurred but can't get location information...");
+                        }
+                    }));
+
+                    dup2(rdr, 0).unwrap();
+                    close(rdr).unwrap();
+                    let mut editor: rustyline::Editor<()> = rustyline::Editor::new();
+                    let mut eof = false;
+                    let result = repl.handle_line(&mut editor, &mut eof);
+                    let _ = std::panic::take_hook();
+                    if expected == result {
+                        std::process::exit(0);
+                    } else {
+                        eprintln!("Expected {:?}, got {:?}", expected, result);
+                        std::process::exit(1);
+                    }
+                }
+                Err(_) => println!("Fork failed"),
             }
-            Err(_) => println!("Fork failed"),
         }
     }
 
@@ -400,6 +409,24 @@ mod tests {
             Err(Error::IllegalDefaultError("bar".into())),
             Parameter::new("bar").set_required(true)?.set_default("foo")
         );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_string_with_spaces_for_argument() -> Result<()> {
+        let repl = Repl::new(())
+            .with_name("test")
+            .with_version("v0.1.0")
+            .with_description("Testing 1, 2, 3...")
+            .with_error_handler(test_error_handler)
+            .add_command(
+                Command::new("foo", foo)
+                    .with_parameter(Parameter::new("bar").set_required(true)?)?
+                    .with_parameter(Parameter::new("baz").set_required(true)?)?
+                    .with_help("Do foo when you can"),
+            );
+        run_repl(repl, "foo \"baz test 123\" foo\n", Ok(()));
 
         Ok(())
     }


### PR DESCRIPTION
Added support for quoted strings.
Now we can capture arguments like this:

```Rust
foo "baz test 123" foo
```
and it would count as two arguments:
```Rust
[
    "baz test 123",
    "foo"
]
```

### Future fixes
- Support for escaped double-quotes.

Closes #1 