### PR TITLE
Return custom Error type to error_handler

### DIFF
--- a/examples/custom_error.rs
+++ b/examples/custom_error.rs
@@ -1,0 +1,47 @@
+extern crate repl_rs;
+
+use std::fmt;
+
+use repl_rs::{Command, Repl, Value};
+use std::collections::HashMap;
+
+/// Example using Repl with a custom error type.
+#[derive(Debug)]
+enum CustomError {
+    ReplError(repl_rs::Error),
+    StringError(String),
+}
+
+impl From<repl_rs::Error> for CustomError {
+    fn from(e: repl_rs::Error) -> Self {
+        CustomError::ReplError(e)
+    }
+}
+
+impl fmt::Display for CustomError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            CustomError::ReplError(e) => write!(f, "REPL Error: {}", e),
+            CustomError::StringError(s) => write!(f, "String Error: {}", s),
+        }
+    }
+}
+
+impl std::error::Error for CustomError {}
+
+// Do nothing, unsuccesfully
+fn hello<T>(
+    _args: HashMap<String, Value>,
+    _context: &mut T,
+) -> Result<Option<String>, CustomError> {
+    Err(CustomError::StringError("Returning an error".to_string()))
+}
+
+fn main() -> Result<(), repl_rs::Error> {
+    let mut repl = Repl::new(())
+        .with_name("MyApp")
+        .with_version("v0.1.0")
+        .with_description("My very cool app")
+        .add_command(Command::new("hello", hello).with_help("Do nothing, unsuccessfully"));
+    repl.run()
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -26,9 +26,6 @@ pub enum Error {
     /// Error parsing a float value
     ParseFloatError(num::ParseFloatError),
 
-    /// Generic error on command
-    CommandError(String),
-
     /// Command not found
     UnknownCommand(String),
 }
@@ -56,7 +53,6 @@ impl fmt::Display for Error {
             ),
             Error::ParseFloatError(error) => write!(f, "Error: {}", error,),
             Error::ParseIntError(error) => write!(f, "Error: {}", error,),
-            Error::CommandError(error) => write!(f, "Error: {}", error),
             Error::UnknownCommand(command) => write!(f, "Error: Unknown command '{}'", command),
         }
     }


### PR DESCRIPTION
This makes the error_handler take the E(rror) type, which allows it to
catch application-level error types.
This also returns this from handle_command, so that it's possible for
command errors to be processed by the error_handler.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>