### PR TITLE
Nix dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,9 @@ edition = "2018"
 [dependencies]
 rustyline = "8.2.0"
 yansi = "0.5.0"
-nix = "0.21.0"
 clap = "2.33.1"
 regex = "1.5.4"
 rustyline-derive = "0.4.0"
+
+[target.'cfg(unix)'.dev-dependencies]
+nix = "0.21.0"

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -322,7 +322,7 @@ impl completion::Completer for Helper {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 mod tests {
     use crate::error::*;
     use crate::repl::{Helper, Repl};
@@ -333,7 +333,6 @@ mod tests {
     use nix::unistd::{close, dup2, fork, pipe, ForkResult};
     use std::collections::HashMap;
     use std::fs::File;
-    use std::io::Write;
     use std::os::unix::io::FromRawFd;
 
     fn test_error_handler<Context>(error: Error, _repl: &Repl<Context, Error>) -> Result<()> {

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -333,6 +333,7 @@ mod tests {
     use nix::unistd::{close, dup2, fork, pipe, ForkResult};
     use std::collections::HashMap;
     use std::fs::File;
+    use std::io::Write;
     use std::os::unix::io::FromRawFd;
 
     fn test_error_handler<Context>(error: Error, _repl: &Repl<Context, Error>) -> Result<()> {


### PR DESCRIPTION
The nix dependency is not available on Windows systems and only required for testing. To run at least the doc tests on Windows the tests in repl.rs are marked as unix specific because they rely on nix.